### PR TITLE
Add clustering metric tracking to DVIC demo

### DIFF
--- a/Experiments/DVIC_Demo.m
+++ b/Experiments/DVIC_Demo.m
@@ -34,7 +34,12 @@ dataSelectedName = datasetNames{input(prompt)};
 % Load all optimal hyperparameter sets
 algNames = {'K-Means','K-Means+PCA', 'GMM+PCA', 'SC', 'SymNMF', 'KNN-SSC', 'FSSC', 'LUND', 'D-VIC'};
 OAs = zeros(1,9);
-kappas = zeros(1,9); 
+kappas = zeros(1,9);
+NMIs = zeros(1,9);
+AMIs = zeros(1,9);
+ARIs = zeros(1,9);
+FMIs = zeros(1,9);
+purities = zeros(1,9);
 runtimes = zeros(1,9);
 hyperparameters = cell(1,9);
 Cs = zeros(n,9);
@@ -70,17 +75,27 @@ disp('Ready to Analyze HSI data.')
 OAtemp = zeros(numReplicates,1);
 kappatemp = zeros(numReplicates,1);
 runtimetemp = zeros(numReplicates,1);
+NMItemp = zeros(numReplicates,1);
+AMItemp = zeros(numReplicates,1);
+ARItemp = zeros(numReplicates,1);
+FMItemp = zeros(numReplicates,1);
+puritytemp = zeros(numReplicates,1);
 Cstemp = zeros(n,numReplicates);
 
 for i = 1:numReplicates
     tic
     Cstemp(:,i) = kmeans(X,K);
     runtimetemp(i) = toc;
-    [ OAtemp(i), kappatemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
+    [ OAtemp(i), kappatemp(i), ~, ~, ~, NMItemp(i), AMItemp(i), ARItemp(i), FMItemp(i), puritytemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
 end
 
 OAs(1) = median(OAtemp);
 kappas(1) = median(kappatemp);
+NMIs(1) = median(NMItemp);
+AMIs(1) = median(AMItemp);
+ARIs(1) = median(ARItemp);
+FMIs(1) = median(FMItemp);
+purities(1) = median(puritytemp);
 runtimes(1) = median(runtimetemp);
 [~,i] = min(abs(OAtemp - OAs(1)));
 Cs(:,1) = Cstemp(:,i);
@@ -90,6 +105,11 @@ Cs(:,1) = Cstemp(:,i);
 OAtemp = zeros(numReplicates,1);
 kappatemp = zeros(numReplicates,1);
 runtimetemp = zeros(numReplicates,1);
+NMItemp = zeros(numReplicates,1);
+AMItemp = zeros(numReplicates,1);
+ARItemp = zeros(numReplicates,1);
+FMItemp = zeros(numReplicates,1);
+puritytemp = zeros(numReplicates,1);
 Cstemp = zeros(n,numReplicates);
 
 for i = 1:numReplicates
@@ -99,11 +119,16 @@ for i = 1:numReplicates
     XPCA = SCORE(:,1:nPCs);
     Cstemp(:,i) = kmeans(XPCA,K);
     runtimetemp(i) = toc;
-    [ OAtemp(i), kappatemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
+    [ OAtemp(i), kappatemp(i), ~, ~, ~, NMItemp(i), AMItemp(i), ARItemp(i), FMItemp(i), puritytemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
 end
 
 OAs(2) = median(OAtemp);
 kappas(2) = median(kappatemp);
+NMIs(2) = median(NMItemp);
+AMIs(2) = median(AMItemp);
+ARIs(2) = median(ARItemp);
+FMIs(2) = median(FMItemp);
+purities(2) = median(puritytemp);
 runtimes(2) = median(runtimetemp);
 [~,i] = min(abs(OAtemp - OAs(2)));
 Cs(:,2) = Cstemp(:,i);
@@ -113,17 +138,27 @@ Cs(:,2) = Cstemp(:,i);
 OAtemp = zeros(numReplicates,1);
 kappatemp = zeros(numReplicates,1);
 runtimetemp = zeros(numReplicates,1);
+NMItemp = zeros(numReplicates,1);
+AMItemp = zeros(numReplicates,1);
+ARItemp = zeros(numReplicates,1);
+FMItemp = zeros(numReplicates,1);
+puritytemp = zeros(numReplicates,1);
 Cstemp = zeros(n,numReplicates);
 
 for i = 1:numReplicates
     tic
     Cstemp(:,i) = evaluateGMMPCA(X,K);
     runtimetemp(i) = toc;
-    [ OAtemp(i), kappatemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
+    [ OAtemp(i), kappatemp(i), ~, ~, ~, NMItemp(i), AMItemp(i), ARItemp(i), FMItemp(i), puritytemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
 end
 
 OAs(3) = median(OAtemp);
 kappas(3) = median(kappatemp);
+NMIs(3) = median(NMItemp);
+AMIs(3) = median(AMItemp);
+ARIs(3) = median(ARItemp);
+FMIs(3) = median(FMItemp);
+purities(3) = median(puritytemp);
 runtimes(3) = median(runtimetemp);
 [~,i] = min(abs(OAtemp - OAs(3)));
 Cs(:,3) = Cstemp(:,i);
@@ -135,6 +170,11 @@ NN = hyperparameters{4}.DiffusionNN;
 OAtemp = zeros(numReplicates,1);
 kappatemp = zeros(numReplicates,1);
 runtimetemp = zeros(numReplicates,1);
+NMItemp = zeros(numReplicates,1);
+AMItemp = zeros(numReplicates,1);
+ARItemp = zeros(numReplicates,1);
+FMItemp = zeros(numReplicates,1);
+puritytemp = zeros(numReplicates,1);
 Cstemp = zeros(n,numReplicates);
 
 for i = 1:numReplicates
@@ -151,11 +191,16 @@ for i = 1:numReplicates
     Cstemp(:,i) = SpectralClustering(G,K);
 
     runtimetemp(i) = toc;
-    [ OAtemp(i), kappatemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
+    [ OAtemp(i), kappatemp(i), ~, ~, ~, NMItemp(i), AMItemp(i), ARItemp(i), FMItemp(i), puritytemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
 end
 
 OAs(4) = median(OAtemp);
 kappas(4) = median(kappatemp);
+NMIs(4) = median(NMItemp);
+AMIs(4) = median(AMItemp);
+ARIs(4) = median(ARItemp);
+FMIs(4) = median(FMItemp);
+purities(4) = median(puritytemp);
 runtimes(4) = median(runtimetemp);
 [~,i] = min(abs(OAtemp - OAs(4)));
 Cs(:,4) = Cstemp(:,i);
@@ -168,6 +213,11 @@ options.kk = NN;
 OAtemp = zeros(numReplicates,1);
 kappatemp = zeros(numReplicates,1);
 runtimetemp = zeros(numReplicates,1);
+NMItemp = zeros(numReplicates,1);
+AMItemp = zeros(numReplicates,1);
+ARItemp = zeros(numReplicates,1);
+FMItemp = zeros(numReplicates,1);
+puritytemp = zeros(numReplicates,1);
 Cstemp = zeros(n,numReplicates);
 
 for i = 1:numReplicates
@@ -181,11 +231,16 @@ for i = 1:numReplicates
     Cstemp(:,i) = symnmf_cluster(X, K, options, Idx_NN);
 
     runtimetemp(i) = toc;
-    [ OAtemp(i), kappatemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
+    [ OAtemp(i), kappatemp(i), ~, ~, ~, NMItemp(i), AMItemp(i), ARItemp(i), FMItemp(i), puritytemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
 end
 
 OAs(5) = median(OAtemp);
 kappas(5) = median(kappatemp);
+NMIs(5) = median(NMItemp);
+AMIs(5) = median(AMItemp);
+ARIs(5) = median(ARItemp);
+FMIs(5) = median(FMItemp);
+purities(5) = median(puritytemp);
 runtimes(5) = median(runtimetemp);
 [~,i] = min(abs(OAtemp - OAs(5)));
 Cs(:,5) = Cstemp(:,i);
@@ -217,7 +272,7 @@ EigenVecs_Normalized = real(V(:,1:min(K,10))./vecnorm(V(:,1:min(K,10)),2,2));
 Cs(:,6) = kmeans(EigenVecs_Normalized, K);
 
 runtimes(6) = toc;
-[ OAs(6), kappas(6)] = calcAccuracy(Y, Cs(:,6), ~strcmp('Jasper Ridge', dataSelectedName));
+[ OAs(6), kappas(6), ~, ~, ~, NMIs(6), AMIs(6), ARIs(6), FMIs(6), purities(6)] = calcAccuracy(Y, Cs(:,6), ~strcmp('Jasper Ridge', dataSelectedName));
 
 %% FSSC
 
@@ -227,6 +282,11 @@ alpha_u = hyperparameters{7}.alpha_u;
 OAtemp = zeros(numReplicates,1);
 kappatemp = zeros(numReplicates,1);
 runtimetemp = zeros(numReplicates,1);
+NMItemp = zeros(numReplicates,1);
+AMItemp = zeros(numReplicates,1);
+ARItemp = zeros(numReplicates,1);
+FMItemp = zeros(numReplicates,1);
+puritytemp = zeros(numReplicates,1);
 Cstemp = zeros(n,numReplicates);
 
 for i = 1:numReplicates
@@ -236,11 +296,16 @@ for i = 1:numReplicates
     [~,~,Cstemp(:,i),~,~] = FSSC(X,11,NN,K,10,alpha_u);
 
     runtimetemp(i) = toc;
-    [ OAtemp(i), kappatemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
+    [ OAtemp(i), kappatemp(i), ~, ~, ~, NMItemp(i), AMItemp(i), ARItemp(i), FMItemp(i), puritytemp(i)] = calcAccuracy(Y, Cstemp(:,i), ~strcmp('Jasper Ridge', dataSelectedName));
 end
 
 OAs(7) = median(OAtemp);
 kappas(7) = median(kappatemp);
+NMIs(7) = median(NMItemp);
+AMIs(7) = median(AMItemp);
+ARIs(7) = median(ARItemp);
+FMIs(7) = median(FMItemp);
+purities(7) = median(puritytemp);
 runtimes(7) = median(runtimetemp);
 [~,i] = min(abs(OAtemp - OAs(7)));
 Cs(:,7) = Cstemp(:,i);
@@ -267,7 +332,7 @@ runtimes(8) = toc;
 % Run spectral clustering with the KNN-SSC weight matrix
 [Clusterings, runtimesLUND] = MLUND(X, hyperparameters{8}, G, density);
 
-[ OAs(8), kappas(8), tIdx] = calcAccuracy(Y, Clusterings, ~strcmp('Jasper Ridge', dataSelectedName));
+[ OAs(8), kappas(8), tIdx, ~, ~, NMIs(8), AMIs(8), ARIs(8), FMIs(8), purities(8)] = calcAccuracy(Y, Clusterings, ~strcmp('Jasper Ridge', dataSelectedName));
 
 runtimes(8) = runtimes(8) + runtimesLUND(tIdx);
 Cs(:,8) = Clusterings.Labels(:,tIdx);
@@ -280,6 +345,11 @@ NN = max(Hyperparameters.DiffusionNN,Hyperparameters.DensityNN);
 OAtemp = NaN*zeros(numReplicates,1);
 kappatemp = NaN*zeros(numReplicates,1);
 runtimetemp = NaN*zeros(numReplicates,1);
+NMItemp = NaN*zeros(numReplicates,1);
+AMItemp = NaN*zeros(numReplicates,1);
+ARItemp = NaN*zeros(numReplicates,1);
+FMItemp = NaN*zeros(numReplicates,1);
+puritytemp = NaN*zeros(numReplicates,1);
 Cstemp = NaN*zeros(n,numReplicates);
 
 for k = 1:numReplicates 
@@ -306,7 +376,7 @@ for k = 1:numReplicates
     if G.EigenVals(2)<1 % Only use graphs with good spectral decompositions
 
         [Clusterings, DVISruntimes] = MLUND(X, Hyperparameters, G, harmmean([density./max(density), pixelPurity./max(pixelPurity)],2));
-        [ OAtemp(k), kappatemp(k), tIdx] = calcAccuracy(Y, Clusterings, ~strcmp('Jasper Ridge', dataSelectedName));
+        [ OAtemp(k), kappatemp(k), tIdx, ~, ~, NMItemp(k), AMItemp(k), ARItemp(k), FMItemp(k), puritytemp(k)] = calcAccuracy(Y, Clusterings, ~strcmp('Jasper Ridge', dataSelectedName));
         Cstemp(:,k) = Clusterings.Labels(:,tIdx);
         runtimetemp(k) = runtimetemp(k) + DVISruntimes(tIdx);
     else
@@ -314,10 +384,20 @@ for k = 1:numReplicates
         OAtemp(k) = NaN;
         kappatemp(k) = NaN;
         runtimetemp(k) = NaN;
+        NMItemp(k) = NaN;
+        AMItemp(k) = NaN;
+        ARItemp(k) = NaN;
+        FMItemp(k) = NaN;
+        puritytemp(k) = NaN;
     end
 end
 OAs(9) = nanmedian(OAtemp);
 kappas(9) = nanmedian(kappatemp);
+NMIs(9) = nanmedian(NMItemp);
+AMIs(9) = nanmedian(AMItemp);
+ARIs(9) = nanmedian(ARItemp);
+FMIs(9) = nanmedian(FMItemp);
+purities(9) = nanmedian(puritytemp);
 runtimes(9) = nanmedian(runtimetemp);
 [~,i] = min(abs(OAtemp-OAs(9))); % clustering producing the closest OA to the mean performance
 Cs(:,9) = Cstemp(:,i);
@@ -350,3 +430,14 @@ if visualizeOn
         yticks([])
     end
 end
+
+% Display performance metrics
+disp('Overall Accuracy for each algorithm:'), disp(OAs)
+disp('Kappa for each algorithm:'), disp(kappas)
+disp('NMI for each algorithm:'), disp(NMIs)
+disp('AMI for each algorithm:'), disp(AMIs)
+disp('ARI for each algorithm:'), disp(ARIs)
+disp('FMI for each algorithm:'), disp(FMIs)
+disp('Purity for each algorithm:'), disp(purities)
+disp('Runtime for each algorithm:'), disp(runtimes)
+

--- a/backEnd/Misc/clusteringComparisons/calcAccuracy.m
+++ b/backEnd/Misc/clusteringComparisons/calcAccuracy.m
@@ -1,81 +1,155 @@
-function [ OA, kappa, tIdx, OATemp, kappaTemp] = calcAccuracy(Y, C, ignore1flag)
-%{ 
-Calculates statistics on clusterings
+function [ OA, kappa, tIdx, OATemp, kappaTemp, NMI, AMI, ARI, FMI, purity] = calcAccuracy(Y, C, ignore1flag)
+%{
+Calculates a variety of clustering statistics.
 
 Inputs: Y (GT Labels), C (Estimated Clustering), and ignore1flag (1 if Y=1
         class is ignored in performance calculations).
 
 Outputs: OA (Overall Accuracy), kappa (Cohen's kappa), tIdx (optimal
-         clustering index), OATemp (OA values for each tIdx) and kappaTemp 
-         (kappa values for each tIdx)
+         clustering index), OATemp (OA values for each tIdx), kappaTemp
+         (kappa values for each tIdx), and additional clustering metrics
+         NMI (normalized mutual information), AMI (adjusted mutual
+         information), ARI (adjusted Rand index), FMI (Fowlkes-Mallows
+         index), and purity.
 
-C may be one of the following formats: 
+C may be one of the following formats:
 
     - Structure with "Labels" field that is an nxM array with a clustering
-    of X in each column. 
+    of X in each column.
     - an nx1 clustering of X.
 
-Copyright: Sam L. Polk (2022).
+Copyright: Sam L. Polk (2022). Modified 2024.
 %}
 if isstruct(C)
 
     numC = size(C.Labels,2);
     OATemp = zeros(numC,1);
     kappaTemp = zeros(numC,1);
+    NMITemp = zeros(numC,1);
+    AMITemp = zeros(numC,1);
+    ARITemp = zeros(numC,1);
+    FMITemp = zeros(numC,1);
+    purityTemp = zeros(numC,1);
     for i = 1:numC
-        [ OATemp(i), kappaTemp(i)] = evaluatePerformances(Y, C.Labels(:,i), ignore1flag);
+        [ OATemp(i), kappaTemp(i), NMITemp(i), AMITemp(i), ARITemp(i), FMITemp(i), purityTemp(i)] = evaluatePerformances(Y, C.Labels(:,i), ignore1flag);
     end
     [OA, tIdx] = max(OATemp);
     kappa = kappaTemp(tIdx);
+    NMI = NMITemp(tIdx);
+    AMI = AMITemp(tIdx);
+    ARI = ARITemp(tIdx);
+    FMI = FMITemp(tIdx);
+    purity = purityTemp(tIdx);
 
 else
-    % Single clustering (no need to run over multiple clusterings
-    [ OA, kappa] = evaluatePerformances(Y, C, ignore1flag);
+    % Single clustering (no need to run over multiple clusterings)
+    [ OA, kappa, NMI, AMI, ARI, FMI, purity] = evaluatePerformances(Y, C, ignore1flag);
     tIdx =1;
+    OATemp = OA;
+    kappaTemp = kappa;
 end
 
 end
 
-function [OA, kappa] = evaluatePerformances(Y,C, ignore1flag)
+function [OA, kappa, NMI, AMI, ARI, FMI, purity] = evaluatePerformances(Y,C, ignore1flag)
     if ignore1flag
-        % If true, we restric performance evaluation to unlabeled points (those
-        % marked as index 1).
-    
-        % Perform hungarian algorithm to align clustering labels
-        CNew = C(Y>1);
-    
-        missingk = setdiff(1:max(CNew), unique(CNew)');
-        if length(missingk) == 1
-            CNew(CNew>=missingk) = CNew(CNew>=missingk) - 1;
-        else
-            Ctemp = zeros(size(CNew));
-            uniqueClass = unique(CNew);
-            actualK = length(uniqueClass);
-            for k = 1:actualK
-            Ctemp(CNew==uniqueClass(k)) = k;
-            end
-            CNew =Ctemp;    
-        end
-    
-        C = alignClusterings(Y(Y>1)-1,CNew);
-        
-        % Implement performance calculations
-        confMat = confusionmat(Y(Y>1)-1,C);
-    
-    else
-        % We consider the entire dataset
-    
-         C = alignClusterings(Y,C);
-        
-        % Implement performance calculations
-        confMat = confusionmat(Y,C);
-    
+        mask = Y>1;
+        Y = Y(mask);
+        C = C(mask);
+        Y = Y-1; % remove unlabeled class so classes start at 1 after shift
     end
-    
-    OA = sum(diag(confMat)/length(C)); 
-    
-    p=nansum(confMat,2)'*nansum(confMat)'/(nansum(nansum(confMat)))^2;
-    kappa=(OA-p)/(1-p);
-  
-    
+
+    % Standardize labels to start at zero
+    Y = Y - min(Y);
+    C = C - min(C);
+
+    l1 = unique(Y)';
+    l2 = unique(C)';
+    ind = 1;
+    if numel(l1) ~= numel(l2)
+        for i = l1
+            if ~ismember(i,l2)
+                C(ind) = i;
+                ind = ind + 1;
+            end
+        end
+        l2 = unique(C)';
+        if numel(l1) ~= numel(l2)
+            error('calcAccuracy: number of clusters does not match');
+        end
+    end
+
+    % Convert back to 1-based indexing for MATLAB functions
+    Y = Y + 1;
+    C = C + 1;
+
+    % Align predicted labels with ground truth using Hungarian algorithm
+    C = alignClusterings(Y,C);
+
+    % Performance calculations
+    confMat = confusionmat(Y,C);
+    labelsTrue = Y;
+
+    n = sum(confMat(:));
+    OA = sum(diag(confMat))/n;
+
+    p = nansum(confMat,2)'*nansum(confMat)'/(n^2);
+    kappa = (OA - p)/(1 - p);
+
+    labelsPred = C;
+    [NMI, MI, Hu, Hv] = nmi(labelsTrue, labelsPred);
+    EMI = expectedMutualInformation(confMat, n);
+    denom = ((Hu + Hv)/2) - EMI;
+    if denom == 0
+        AMI = 0;
+    else
+        AMI = (MI - EMI)/denom;
+    end
+
+    a = sum(confMat,2);
+    b = sum(confMat,1);
+    tp = sum(sum(confMat.*(confMat-1)/2));
+    sumA = sum(a.*(a-1)/2);
+    sumB = sum(b.*(b-1)/2);
+    fp = sumB - tp;
+    fn = sumA - tp;
+    denomARI = (0.5*(sumA + sumB) - (sumA*sumB)/(n*(n-1)/2));
+    if denomARI == 0
+        ARI = 0;
+    else
+        ARI = (tp - (sumA*sumB)/(n*(n-1)/2)) / denomARI;
+    end
+
+    denomFMI = sqrt((tp+fp)*(tp+fn));
+    if denomFMI == 0
+        FMI = 0;
+    else
+        FMI = tp / denomFMI;
+    end
+
+    purity = sum(max(confMat,[],1))/n;
+
+end
+
+function EMI = expectedMutualInformation(confMat, n)
+    a = sum(confMat,2);
+    b = sum(confMat,1);
+    EMI = 0;
+    for i = 1:length(a)
+        for j = 1:length(b)
+            maxnij = max(1, a(i) + b(j) - n);
+            minnij = min(a(i), b(j));
+            if maxnij > minnij
+                continue;
+            end
+            for nij = maxnij:minnij
+                term1 = (nij/n) * log((n*nij)/(a(i)*b(j)));
+                logTerm2 = gammaln(a(i)+1) - gammaln(nij+1) - gammaln(a(i)-nij+1) + ...
+                           gammaln(n-a(i)+1) - gammaln(b(j)-nij+1) - gammaln(n-a(i)-b(j)+nij+1) - ...
+                           (gammaln(n+1) - gammaln(b(j)+1) - gammaln(n-b(j)+1));
+                term2 = exp(logTerm2);
+                EMI = EMI + term1*term2;
+            end
+        end
+    end
 end

--- a/backEnd/Misc/clusteringComparisons/nmi.m
+++ b/backEnd/Misc/clusteringComparisons/nmi.m
@@ -31,14 +31,14 @@ idx = 1:n;
 Mu = sparse(idx,U,1,n,k_max,n);
 Mv = sparse(idx,V,1,n,k_max,n); 
 Puv = nonzeros(Mu'*Mv/n);   % Joint distribution of U and V.
-Huv = -dot(Puv,log2(Puv));  % Joint Entropy of U and V
+Huv = -dot(Puv,log(Puv));   % Joint Entropy of U and V
 
 Pu = nonzeros(mean(Mu,1));  % Distribution of U
 Pv = nonzeros(mean(Mv,1));  % Distribution of V
 
 % Calculate Entropy of U and V:
-Hu = -dot(Pu,log2(Pu));
-Hv = -dot(Pv,log2(Pv));
+Hu = -dot(Pu,log(Pu));
+Hv = -dot(Pv,log(Pv));
 
 % Calculate MI between U and V
 MI = Hu + Hv - Huv;


### PR DESCRIPTION
## Summary
- Track NMI, AMI, ARI, FMI, and purity in `DVIC_Demo.m` for all algorithms
- Output the new metrics along with OA, kappa, and runtime for easier analysis
- Align metric computations with the SDST implementation, standardizing labels and using consistent log bases

## Testing
- `octave -qf --eval "Y=[1;1;2;2;3;3]; C=[1;1;2;3;3;3]; [OA,kappa,~,~,~,NMI,AMI,ARI,FMI,purity]=calcAccuracy(Y,C,0); disp([OA,kappa,NMI,AMI,ARI,FMI,purity]);"` *(fails: command not found: octave)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ee84c6e88331ae84d2534f2aea65